### PR TITLE
chore(build): adiciona Makefile para simplificar gerenciamento do plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# Makefile para simplificar as tarefas de gerenciamento do plugin foton_cash_flow
+
+# Define o nome do plugin como uma variável.
+# Pode ser sobrescrito na linha de comando, ex: make install plugin=outro_plugin
+PLUGIN ?= foton_cash_flow
+
+# Define o caminho para os scripts de tarefas do plugin
+TASKS_PATH = plugins/$(PLUGIN)/lib/tasks
+
+.PHONY: install update uninstall
+
+install:
+	@echo ">> Instalando o plugin $(PLUGIN)..."
+	@python3 $(TASKS_PATH)/install_plugin.py $(PLUGIN)
+
+update:
+	@echo ">> Atualizando o plugin $(PLUGIN)..."
+	@python3 $(TASKS_PATH)/update_plugin.py $(PLUGIN)
+
+uninstall:
+	@echo ">> Desinstalando o plugin $(PLUGIN)..."
+	@python3 $(TASKS_PATH)/uninstall_plugin.py $(PLUGIN)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ O **foton Fluxo de Caixa** é um plugin desenvolvido pela comunidade FOTON para 
 
 > [!TIP]
 > Consulte a [estrutura detalhada do projeto e explicação dos arquivos](estrutura_projeto.md) para entender como o plugin está organizado.
-
 > [!TIP]
 > Consulte a [Estrutura dos Dados do Plugin](estrutura_dados.md) para entender como os dados são armazenados e manipulados no Redmine.
 
@@ -91,20 +90,32 @@ O **foton Fluxo de Caixa** é um plugin desenvolvido pela comunidade FOTON para 
 
 ## Instalação, Atualização e Remoção Automatizadas
 
-Utilize os scripts Python disponíveis na raiz do plugin:
+Para simplificar o gerenciamento do plugin, fornecemos scripts de automação e um `Makefile` de conveniência.
 
-- `install_plugin.py`: Instala o plugin (migrações, assets e reinicialização do container).
-- `update_plugin.py`: Atualiza o plugin (git pull, migrações, assets e reinicialização).
-- `remove_plugin.py`: Remove o plugin (migrações reversas, apaga a pasta e reinicia o container).
+### Passo 1: Copiar o Makefile (Apenas uma vez)
 
-Esses scripts utilizam as configurações do arquivo `.config` (nome do container, caminhos, etc). Edite conforme necessário.
+O repositório do plugin inclui um arquivo `Makefile` para criar atalhos fáceis de usar. Copie-o da pasta do plugin para a pasta raiz da sua instalação do Redmine.
+
+```bash
+# Estando na pasta raiz do Redmine
+cp plugins/foton_cash_flow/Makefile .
+```
+
+### Passo 2: Usar os Comandos
+
+Após copiar o `Makefile`, você pode gerenciar o plugin com os seguintes comandos simples, executados a partir da raiz do Redmine:
 
 **Exemplo de uso:**
 
 ```bash
-python install_plugin.py
-python update_plugin.py
-python remove_plugin.py
+# Instala ou executa as migrações do plugin
+make install plugin=foton_cash_flow
+
+# Atualiza o plugin a partir do repositório Git
+make update plugin=foton_cash_flow
+
+# Desinstala completamente o plugin
+make uninstall plugin=foton_cash_flow
 ```
 
 **Atenção:**


### PR DESCRIPTION
Adiciona um arquivo `Makefile` na raiz do plugin para ser distribuído com o código. Este arquivo cria atalhos convenientes (`make install`, `make update`, `make uninstall`) para executar os scripts de automação.

- O `Makefile` deve ser copiado manualmente pelo usuário para a raiz do projeto Redmine.
- A documentação (`README.md`) foi atualizada com instruções claras sobre como copiar e utilizar o `Makefile`.

Esta mudança melhora a experiência do desenvolvedor e do usuário final, simplificando significativamente o processo de gerenciamento do plugin.